### PR TITLE
Fix Import into Boost

### DIFF
--- a/src/ImportUtil.ts
+++ b/src/ImportUtil.ts
@@ -158,7 +158,7 @@ export default class ImportUtil {
     console.log(`[${dealId}] Importing ${existingPath}`);
     try {
       if (!options.dryRun) {
-        const response = await options.marketApiClient.call('BoostOfflineDealWithData', [dealId, path.resolve(existingPath)], 'false');
+        const response = await options.marketApiClient.call('BoostOfflineDealWithData', [dealId, path.resolve(existingPath), false]);
         if (response.error) {
           throw response.error;
         }

--- a/src/ImportUtil.ts
+++ b/src/ImportUtil.ts
@@ -158,7 +158,7 @@ export default class ImportUtil {
     console.log(`[${dealId}] Importing ${existingPath}`);
     try {
       if (!options.dryRun) {
-        const response = await options.marketApiClient.call('BoostOfflineDealWithData', [dealId, path.resolve(existingPath)], false);
+        const response = await options.marketApiClient.call('BoostOfflineDealWithData', [dealId, path.resolve(existingPath)], 'false');
         if (response.error) {
           throw response.error;
         }

--- a/src/ImportUtil.ts
+++ b/src/ImportUtil.ts
@@ -158,7 +158,7 @@ export default class ImportUtil {
     console.log(`[${dealId}] Importing ${existingPath}`);
     try {
       if (!options.dryRun) {
-        const response = await options.marketApiClient.call('BoostOfflineDealWithData', [dealId, path.resolve(existingPath)]);
+        const response = await options.marketApiClient.call('BoostOfflineDealWithData', [dealId, path.resolve(existingPath)], false);
         if (response.error) {
           throw response.error;
         }

--- a/src/ImportUtil.ts
+++ b/src/ImportUtil.ts
@@ -158,7 +158,7 @@ export default class ImportUtil {
     console.log(`[${dealId}] Importing ${existingPath}`);
     try {
       if (!options.dryRun) {
-        const response = await options.marketApiClient.call('BoostOfflineDealWithData', [dealId, path.resolve(existingPath), false]);
+        const response = await options.marketApiClient.call('BoostOfflineDealWithData', [dealId, path.resolve(existingPath), 'false']);
         if (response.error) {
           throw response.error;
         }


### PR DESCRIPTION
This change adds a new pram to the Import API call - setting the delete after import flag to false. 
This flag is required for newer versions of boost