### PR TITLE
Stop importing when X number of deals are waiting for Commp to run

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,21 +30,23 @@ Usage: singularity-import-boost [options]
 A tool to automatically import deals to boost
 
 Options:
-  -c, --client <addresses...>                List of client addresses to filter the deal proposals
-  -p, --path <paths...>                      List of paths to find the CAR files
-  -s, --since <duration>                     Import deals that are proposed since this many seconds old and skip those that are older (default: "1d")
-  -sd, --sealing-duration <duration>         Import deals whose start time is more than this many seconds in the future to account for time spent for sealing. Otherwise, sealing will fail if it does not finish before the start time of the deal (default: "6h")
-  -u, --url-template <template>              The URL template to download CAR files, if it cannot be found from the specified paths. i.e. https://www.download.org/{dataCid}.car, https://www.download.org/{pieceCid}.car
-  -dt, --download-threads <threads>          The number of concurrent threads for downloading (default: 8)
-  -dr, --download-retries <retries>          The number of exponential retries for each download (default: 3)
-  -o, --download-folder <folder>             The folder to save the downloaded CAR files
-  -i, --interval <duration>                  The interval in seconds between handling applicable deals, including both file downloads and deal importing. The timer starts when the previous import begins so it is possible to have concurrent imports or downloads if the interval is too small, which is probably
-                                             fine with boost. (default: "1m")
-  -dc, --download-concurrency <concurrency>  This sets an upper limit of concurrent downloads (default: 1)
-  -pc1, --max-pc1 <max_pc1>                  [Not implemented] The maximum number of PC1s to run concurrently, once reached, stop importing or downloading new deals. 0 for unlimited. (default: 0)
-  -d, --dry-run                              Do not import deals, just print the deals that would be imported or downloaded (default: false)
-  -l, --loop                                 Keep monitoring the incoming deals and perform the import indefinitely (default: false)
-  -h, --help                                 display help for command
+  -c, --client <addresses...>                    List of client addresses to filter the deal proposals
+  -p, --path <paths...>                          List of paths to find the CAR files
+  -s, --since <duration>                         Import deals that are proposed since this many seconds old and skip those that are older (default: "1d")
+  -sd, --sealing-duration <duration>             Import deals whose start time is more than this many seconds in the future to account for time spent for sealing. Otherwise, sealing will fail if it does not finish before the start time of the deal (default: "6h")
+  -u, --url-template <template>                  The URL template to download CAR files, if it cannot be found from the specified paths. i.e. https://www.download.org/{dataCid}.car, https://www.download.org/{pieceCid}.car
+  -dt, --download-threads <threads>              The number of concurrent threads for downloading (default: 8)
+  -dr, --download-retries <retries>              The number of exponential retries for each download (default: 3)
+  -o, --download-folder <folder>                 The folder to save the downloaded CAR files
+  -i, --interval <duration>                      The interval in seconds between handling applicable deals, including both file downloads and deal importing. The timer starts when the previous import begins so it is possible to have concurrent imports or downloads if the interval is too small, which is probably fine with boost. (default: "1m")
+  -dc, --download-concurrency <concurrency>      This sets an upper limit of concurrent downloads (default: 1)
+  -pc, --max-pc1 <max_pc1>                       The maximum number of PC1s to run concurrently, once reached, stop importing or downloading new deals. 0 for unlimited. [Hack] For 64G miner, this value needs to be doubled. (default: 0)
+  -ppc, --max-potential-pc1 <max_potential_pc1>  The maximum number of potential PC1s to run concurrently, the difference between this and --max-pc1 is, this includes all deals that will become PC1 shortly, including AP, deals pending publishing and being published. [Hack] For 64G miner, this value needs to be doubled. (default: 0)
+  -vc, --pending-commp <max_commp>               The maximum number of deals waiting in the Verifying Commp State (default: 0)
+  -r, --reverse                                  Import deals in reverse order, i.e. from the oldest to the newest (default: false)
+  -d, --dry-run                                  Do not import deals, just print the deals that would be imported or downloaded (default: false)
+  -l, --loop                                     Keep monitoring the incoming deals and perform the import indefinitely (default: false)
+  -h, --help                                     display help for command
 
 
 Environment Variables:
@@ -57,7 +59,7 @@ Example Usage:
     $ singularity-import-boost -p /path/to/car -i 0 -l
   - Import one deal every 20 minutes with multiple paths
     $ singularity-import-boost -p /path1/to/car -p /path2/to/car -i 20m -l
-  - Import deals from a specific client and the file can be downloaded from their HTTP server. 
+  - Import deals from a specific client and the file can be downloaded from their HTTP server.
     $ singularity-import-boost -c f1xxxx -u https://www.download.org/{pieceCid}.car -o ./downloads -i 0 -l
 
 ```

--- a/src/ImportUtil.ts
+++ b/src/ImportUtil.ts
@@ -192,6 +192,7 @@ export default class ImportUtil {
     }
     let pc1 = 0;
     let potentialPc1 = 0;
+    let pendingCompp = 0;
     for (const deal of deals) {
       const pieceSize = Number(deal.PieceSize.n);
       if (deal.Message === 'Sealer: PreCommit1') {
@@ -201,6 +202,8 @@ export default class ImportUtil {
         deal.Message === 'Awaiting Publish Confirmation' ||
       deal.Message === 'Adding to Sector') {
         potentialPc1 += pieceSize;
+      } else if (deal.Message === 'Verifying Commp') {
+        pendingCompp += pieceSize;
       }
     }
     if (options.maxPc1 > 0 && pc1 / s32g >= options.maxPc1) {
@@ -210,6 +213,10 @@ export default class ImportUtil {
     for (const deal of deals) {
       if (options.maxPotentialPc1 > 0 && potentialPc1 / s32g >= options.maxPotentialPc1) {
         console.log(`Skipping import because ${potentialPc1 / s32g} PC1 are potentially running - max: ${options.maxPotentialPc1}.`);
+        return;
+      }
+      if (options.pendingCompp > 0 && pendingCompp / s32g >= options.pendingCompp) {
+        console.log(`Skipping import because ${pendingCompp / s32g} Deals are waiting Commp- max: ${options.pendingCompp}.`);
         return;
       }
       if (deal.Message !== 'Awaiting Offline Data Import') {

--- a/src/ImportUtil.ts
+++ b/src/ImportUtil.ts
@@ -192,7 +192,7 @@ export default class ImportUtil {
     }
     let pc1 = 0;
     let potentialPc1 = 0;
-    let pendingCompp = 0;
+    let pendingCommp = 0;
     for (const deal of deals) {
       const pieceSize = Number(deal.PieceSize.n);
       if (deal.Message === 'Sealer: PreCommit1') {
@@ -203,7 +203,7 @@ export default class ImportUtil {
       deal.Message === 'Adding to Sector') {
         potentialPc1 += pieceSize;
       } else if (deal.Message === 'Verifying Commp') {
-        pendingCompp += pieceSize;
+        pendingCommp += pieceSize;
       }
     }
     if (options.maxPc1 > 0 && pc1 / s32g >= options.maxPc1) {
@@ -215,8 +215,8 @@ export default class ImportUtil {
         console.log(`Skipping import because ${potentialPc1 / s32g} PC1 are potentially running - max: ${options.maxPotentialPc1}.`);
         return;
       }
-      if (options.pendingCompp > 0 && pendingCompp / s32g >= options.pendingCompp) {
-        console.log(`Skipping import because ${pendingCompp / s32g} Deals are waiting Commp- max: ${options.pendingCompp}.`);
+      if (options.pendingCommp > 0 && pendingCommp / s32g >= options.pendingCommp) {
+        console.log(`Skipping import because ${pendingCommp / s32g} Deals are waiting Commp- max: ${options.pendingCommp}.`);
         return;
       }
       if (deal.Message !== 'Awaiting Offline Data Import') {

--- a/src/ImportUtil.ts
+++ b/src/ImportUtil.ts
@@ -203,7 +203,7 @@ export default class ImportUtil {
       deal.Message === 'Adding to Sector') {
         potentialPc1 += pieceSize;
       } else if (deal.Message === 'Verifying Commp') {
-        pendingCommp += pieceSize;
+        pendingCommp += 1;
       }
     }
     if (options.maxPc1 > 0 && pc1 / s32g >= options.maxPc1) {
@@ -215,8 +215,8 @@ export default class ImportUtil {
         console.log(`Skipping import because ${potentialPc1 / s32g} PC1 are potentially running - max: ${options.maxPotentialPc1}.`);
         return;
       }
-      if (options.pendingCommp > 0 && pendingCommp / s32g >= options.pendingCommp) {
-        console.log(`Skipping import because ${pendingCommp / s32g} Deals are waiting Commp- max: ${options.pendingCommp}.`);
+      if (options.pendingCommp > 0 && pendingCommp >= options.pendingCommp) {
+        console.log(`Skipping import because ${pendingCommp} Deals are waiting Commp- max: ${options.pendingCommp}.`);
         return;
       }
       if (deal.Message !== 'Awaiting Offline Data Import') {

--- a/src/ImportUtil.ts
+++ b/src/ImportUtil.ts
@@ -216,7 +216,7 @@ export default class ImportUtil {
         return;
       }
       if (options.pendingCommp > 0 && pendingCommp >= options.pendingCommp) {
-        console.log(`Skipping import because ${pendingCommp} Deals are waiting Commp- max: ${options.pendingCommp}.`);
+        console.log(`Skipping import because ${pendingCommp} Deals are Verifying Commp - max: ${options.pendingCommp}.`);
         return;
       }
       if (deal.Message !== 'Awaiting Offline Data Import') {

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -17,7 +17,7 @@ export interface ImportOptions {
   downloadConcurrency: number,
   maxPc1: number,
   maxPotentialPc1: number,
-  pendingCompp: number,
+  pendingCommp: number,
   reverse: boolean,
   dryRun: boolean,
   loop: boolean,

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -17,6 +17,7 @@ export interface ImportOptions {
   downloadConcurrency: number,
   maxPc1: number,
   maxPotentialPc1: number,
+  pendingCompp: number,
   reverse: boolean,
   dryRun: boolean,
   loop: boolean,

--- a/src/singularity-import-boost.ts
+++ b/src/singularity-import-boost.ts
@@ -36,7 +36,7 @@ program.option('-c, --client <addresses...>', 'List of client addresses to filte
     'The maximum number of potential PC1s to run concurrently, the difference between this and --max-pc1 is, ' +
     'this includes all deals that will become PC1 shortly, including AP, deals pending publishing and being published. ' +
     '[Hack] For 64G miner, this value needs to be doubled.', Number, 0)
-  .option('-vc, --pending-commp <max_commp>', 'the maximum number of deals waiting for commp to run', Number, 0)
+  .option('-vc, --pending-commp <max_commp>', 'The maximum number of deals waiting in the Verifying Commp State', Number, 0)
   .option('-r, --reverse', 'Import deals in reverse order, i.e. from the oldest to the newest', false)
   .option('-d, --dry-run', 'Do not import deals, just print the deals that would be imported or downloaded', false)
   .option('-l, --loop', 'Keep monitoring the incoming deals and perform the import indefinitely', false)

--- a/src/singularity-import-boost.ts
+++ b/src/singularity-import-boost.ts
@@ -36,7 +36,7 @@ program.option('-c, --client <addresses...>', 'List of client addresses to filte
     'The maximum number of potential PC1s to run concurrently, the difference between this and --max-pc1 is, ' +
     'this includes all deals that will become PC1 shortly, including AP, deals pending publishing and being published. ' +
     '[Hack] For 64G miner, this value needs to be doubled.', Number, 0)
-  .option('-pc, --pending-commp <max_commp>', 'the maximum number of deals waiting for commp to run', Number, 0)
+  .option('-vc, --pending-commp <max_commp>', 'the maximum number of deals waiting for commp to run', Number, 0)
   .option('-r, --reverse', 'Import deals in reverse order, i.e. from the oldest to the newest', false)
   .option('-d, --dry-run', 'Do not import deals, just print the deals that would be imported or downloaded', false)
   .option('-l, --loop', 'Keep monitoring the incoming deals and perform the import indefinitely', false)

--- a/src/singularity-import-boost.ts
+++ b/src/singularity-import-boost.ts
@@ -36,6 +36,7 @@ program.option('-c, --client <addresses...>', 'List of client addresses to filte
     'The maximum number of potential PC1s to run concurrently, the difference between this and --max-pc1 is, ' +
     'this includes all deals that will become PC1 shortly, including AP, deals pending publishing and being published. ' +
     '[Hack] For 64G miner, this value needs to be doubled.', Number, 0)
+  .option('-pc, --pending-commp <max_commp>', 'the maximum number of deals waiting for commp to run', Number, 0)
   .option('-r, --reverse', 'Import deals in reverse order, i.e. from the oldest to the newest', false)
   .option('-d, --dry-run', 'Do not import deals, just print the deals that would be imported or downloaded', false)
   .option('-l, --loop', 'Keep monitoring the incoming deals and perform the import indefinitely', false)


### PR DESCRIPTION
as it says on the tin

Stop 100 Deals importing into boost and overrunning when sitting in Commp state - used with the max PC1 option to stop overrun. 

IE: max 100PC1 but 50 deals are pending Commp, we keep importing until we hit 100 running PC1 but still have 50 on the way because they have just been pending Commp and not registered as potential sectors yet.

It could be run inside the max potential PC1 check but it feels cleaner to have it as its own option. 